### PR TITLE
Add github actions cont_integration workflow

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,0 +1,58 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+
+  build-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.53.0 # STABLE
+          - 1.46.0 # MSRV
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Set default toolchain
+        run: rustup default ${{ matrix.rust }}
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add clippy
+        run: rustup component add clippy
+      - name: Update toolchain
+        run: rustup update
+      - name: Build
+        run: cargo build
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test
+
+  format:
+    name: Rust format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add rustfmt
+        run: rustup component add rustfmt
+      - name: Update toolchain
+        run: rustup update
+      - name: Check fmt
+        run: cargo fmt --all -- --config format_code_in_doc_comments=true --check

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
   <p>
     <a href="https://crates.io/crates/bdk-reserves"><img alt="Crate Info" src="https://img.shields.io/crates/v/bdk-reserves.svg"/></a>
-    <a href="https://github.com/bitcoindevkit/bdk/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
+    <a href="https://github.com/ulrichard/bdk-reserves/blob/master/LICENSE"><img alt="MIT or Apache-2.0 Licensed" src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg"/></a>
+    <a href="https://github.com/ulrichard/bdk-reserves/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/ulrichard/bdk-reserves/workflows/CI/badge.svg"></a>
     <a href="https://docs.rs/bdk-reserves"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-reserves-green"/></a>
     <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html"><img alt="Rustc Version 1.46+" src="https://img.shields.io/badge/rustc-1.46%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -102,7 +102,7 @@ where
                 value: 0,
                 script_pubkey: Builder::new().push_opcode(opcodes::OP_TRUE).into_script(),
             }),
-            final_script_sig: Some(Script::default()), // "finalize" the input with an empty scriptSig
+            final_script_sig: Some(Script::default()), /* "finalize" the input with an empty scriptSig */
             ..Default::default()
         };
 

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -334,7 +334,7 @@ mod test {
             .iter()
             .fold(0, |acc, i| acc + i.partial_sigs.len());
         assert_eq!(num_sigs, num_inp - 1);
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let spendable = wallet.verify_proof(&psbt, &message)?;
         assert_eq!(spendable, balance);
@@ -551,14 +551,14 @@ mod test {
         };
         let finalized = wallet1.sign(&mut psbt, signopts.clone())?;
         assert_eq!(count_signatures(&psbt), (num_inp - 1, 1, 0));
-        assert_eq!(finalized, false);
+        assert!(!finalized);
 
         let finalized = wallet2.sign(&mut psbt, signopts.clone())?;
         assert_eq!(
             count_signatures(&psbt),
             ((num_inp - 1) * 2, num_inp, num_inp - 1)
         );
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         // 2 signatures are enough. Just checking what happens...
         let finalized = wallet3.sign(&mut psbt, signopts.clone())?;
@@ -566,14 +566,14 @@ mod test {
             count_signatures(&psbt),
             ((num_inp - 1) * 2, num_inp, num_inp - 1)
         );
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let finalized = wallet1.finalize_psbt(&mut psbt, signopts)?;
         assert_eq!(
             count_signatures(&psbt),
             ((num_inp - 1) * 2, num_inp, num_inp - 1)
         );
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let spendable = wallet1.verify_proof(&psbt, &message)?;
         assert_eq!(spendable, balance);


### PR DESCRIPTION
I added a simple CI pipeline that does format and clippy checks, and runs tests against Rust 1.46 and 1.53. I also fixed a format error and some clippy errors and added a CI status button to the README.